### PR TITLE
Add custom rrule to speed up AD with mapped functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,10 +3,12 @@ uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
 version = "0.1.1"
 
 [deps]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+ChainRulesCore = "1"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -12,8 +12,9 @@ ChainRulesCore = "1"
 julia = "1"
 
 [extras]
+ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 
 [targets]
-test = ["Documenter", "ForwardDiff"]
+test = ["ChainRulesTestUtils", "Documenter", "ForwardDiff"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ChangesOfVariables"
 uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ changes for functions that perform a change of variables (like coordinate
 transformations).
 
 `ChangesOfVariables` is a very lightweight package and has no dependencies
-beyond `Base`, `LinearAlgebra` and `Test`.
+beyond `Base`, `LinearAlgebra`, `Test` and `ChainRulesCore`.
 
 ## Documentation
 

--- a/src/ChangesOfVariables.jl
+++ b/src/ChangesOfVariables.jl
@@ -9,6 +9,7 @@ transformations).
 """
 module ChangesOfVariables
 
+using ChainRulesCore
 using LinearAlgebra
 using Test
 

--- a/src/with_ladj.jl
+++ b/src/with_ladj.jl
@@ -82,7 +82,6 @@ end
 
 function _with_ladj_on_mapped(map_or_bc::F, y_with_ladj) where {F<:Union{typeof(map),typeof(broadcast)}}
     y = map_or_bc(first, y_with_ladj)
-    ladj = sum(map_or_bc(last, y_with_ladj))
     ladj = sum(Broadcast.instantiate(Broadcast.broadcasted(last, y_with_ladj)))
     (y, ladj)
 end

--- a/src/with_ladj.jl
+++ b/src/with_ladj.jl
@@ -79,12 +79,14 @@ end
 @inline _get_y(y_with_ladj::NTuple{2,Any,}) = y_with_ladj[1]
 @inline _get_ladj(y_with_ladj::NTuple{2,Any}) = y_with_ladj[2]
 
-_with_ladj_on_mapped(map_or_bc::Function, y_with_ladj::Tuple{Any,Real}) = y_with_ladj
+function _with_ladj_on_mapped(map_or_bc::F, y_with_ladj::Tuple{Any,Real})  where {F<:Union{typeof(map),typeof(broadcast)}}
+    return y_with_ladj
+end
 
 function _with_ladj_on_mapped(map_or_bc::F, y_with_ladj) where {F<:Union{typeof(map),typeof(broadcast)}}
     y = map_or_bc(first, y_with_ladj)
     ladj = sum(map_or_bc(last, y_with_ladj))
-    #ladj = sum(_get_ladj, y_with_ladj)
+    ladj = sum(Broadcast.instantiate(Broadcast.broadcasted(last, y_with_ladj)))
     (y, ladj)
 end
 

--- a/src/with_ladj.jl
+++ b/src/with_ladj.jl
@@ -84,7 +84,17 @@ _with_ladj_on_mapped(map_or_bc::Function, y_with_ladj::Tuple{Any,Real}) = y_with
 function _with_ladj_on_mapped(map_or_bc::Function, y_with_ladj)
     y = map_or_bc(_get_y, y_with_ladj)
     ladj = sum(map_or_bc(_get_ladj, y_with_ladj))
+    #ladj = sum(_get_ladj, y_with_ladj)
     (y, ladj)
+end
+
+function _with_ladj_on_mapped_pullback(thunked_ΔΩ)
+    ys, ladj = ChainRulesCore.unthunk(thunked_ΔΩ)
+    NoTangent(), NoTangent(), broadcast(x -> (x, ladj), ys)
+end
+
+function ChainRulesCore.rrule(::typeof(ChangesOfVariables._with_ladj_on_mapped), map_or_bc::Function, y_with_ladj)
+    return ChangesOfVariables._with_ladj_on_mapped(map_or_bc, y_with_ladj), _with_ladj_on_mapped_pullback
 end
 
 function with_logabsdet_jacobian(mapped_f::Base.Fix1{<:Union{typeof(map),typeof(broadcast)}}, X)

--- a/src/with_ladj.jl
+++ b/src/with_ladj.jl
@@ -82,7 +82,7 @@ end
 
 function _with_ladj_on_mapped(map_or_bc::F, y_with_ladj) where {F<:Union{typeof(map),typeof(broadcast)}}
     y = map_or_bc(first, y_with_ladj)
-    ladj = sum(Broadcast.instantiate(Broadcast.broadcasted(last, y_with_ladj)))
+    ladj = sum(last, y_with_ladj)
     (y, ladj)
 end
 
@@ -92,7 +92,7 @@ end
 struct WithLadjOnMappedPullback{YLT} <: Function end
 function (::WithLadjOnMappedPullback{YLT})(thunked_ΔΩ) where YLT
     ys, ladj = unthunk(thunked_ΔΩ)
-    return NoTangent(), NoTangent(), broadcast((y, l) -> Tangent{YLT}(y, l), ys, ladj)
+    return NoTangent(), NoTangent(), map(y -> Tangent{YLT}(y, ladj), ys)
 end
 
 function ChainRulesCore.rrule(::typeof(_with_ladj_on_mapped), map_or_bc::F, y_with_ladj) where {F<:Union{typeof(map),typeof(broadcast)}}

--- a/src/with_ladj.jl
+++ b/src/with_ladj.jl
@@ -76,9 +76,6 @@ export with_logabsdet_jacobian
 end
 
 
-@inline _get_y(y_with_ladj::NTuple{2,Any,}) = y_with_ladj[1]
-@inline _get_ladj(y_with_ladj::NTuple{2,Any}) = y_with_ladj[2]
-
 function _with_ladj_on_mapped(map_or_bc::F, y_with_ladj::Tuple{Any,Real})  where {F<:Union{typeof(map),typeof(broadcast)}}
     return y_with_ladj
 end

--- a/src/with_ladj.jl
+++ b/src/with_ladj.jl
@@ -91,7 +91,7 @@ function _with_ladj_on_mapped_pullback(thunked_ΔΩ)
     return NoTangent(), NoTangent(), tuple.(ys, ladj)
 end
 
-function ChainRulesCore.rrule(::typeof(_with_ladj_on_mapped), map_or_bc::Function, y_with_ladj)
+function ChainRulesCore.rrule(::typeof(_with_ladj_on_mapped), map_or_bc::F, y_with_ladj) where {F<:Union{typeof(map),typeof(broadcast)}}
     return _with_ladj_on_mapped(map_or_bc, y_with_ladj), _with_ladj_on_mapped_pullback
 end
 

--- a/test/test_with_ladj.jl
+++ b/test/test_with_ladj.jl
@@ -5,8 +5,9 @@ using Test
 
 using LinearAlgebra
 
-using ChangesOfVariables: test_with_logabsdet_jacobian, _with_ladj_on_mapped
-using ChainRulesCore
+using ChangesOfVariables
+using ChangesOfVariables: test_with_logabsdet_jacobian
+using ChainRulesTestUtils
 
 include("getjacobian.jl")
 
@@ -63,10 +64,7 @@ include("getjacobian.jl")
 
     @testset "rrules" begin
         for map_or_bc in (map, broadcast)
-            x = [(1, 2), (3, 4), (5, 6)]
-            y, back = rrule(_with_ladj_on_mapped, map_or_bc, x)
-            @test y == ([1, 3, 5], 12) == _with_ladj_on_mapped(map_or_bc, x)
-            @test back(@thunk ([7, 8, 9], 12)) == (ChainRulesCore.NoTangent(), ChainRulesCore.NoTangent(), [(7, 12), (8, 12), (9, 12)])
+            test_rrule(ChangesOfVariables._with_ladj_on_mapped, map_or_bc, [(1.0, 2.0), (3.0, 4.0), (5.0, 6.0)])
         end
     end
 end


### PR DESCRIPTION
AD of `_with_ladj_on_mapped` causes a significant overhead when using AD on `with_logabsdet_jacobian` with mapped/broadcasted functions. This PR adds a custom `ChainRulesCore.rrule` for `_with_ladj_on_mapped` that results in a siginificant speedup. GC overhead is also reduced.

Pro: Very significant speed gain in the benchmark example below. Should be be similar for other lightweight transformations (example uses a `log`-trafo).

Con: The price is adding ChainRulesCore as a dependency

This would make ChangesOfVariables itself less lightweight. On the other hand it's likely that packages that we'd want to depend on ChangesOfVariables will depend on ChainRulesCore already anyway (directly or indirectly).

Benchmark example:

```julia
using ChangesOfVariables, LinearAlgebra, Zygote, BenchmarkTools

function foo(xs)
    ys, ladj = with_logabsdet_jacobian(Base.Fix1(broadcast, log), xs)
    dot(ys, ys) + ladj
end

grad_foo(xs) = Zygote.gradient(foo, xs)[1]

xs = rand(10^3);
grad_foo(xs);

@benchmark grad_foo($xs)
```

Without this PR (no custom rrule):

```julia
julia> @benchmark grad_foo($xs)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  30.507 μs …   2.065 ms  ┊ GC (min … max):  0.00% … 95.86%
 Time  (median):     46.969 μs               ┊ GC (median):     0.00%
 Time  (mean ± σ):   58.705 μs ± 122.055 μs  ┊ GC (mean ± σ):  15.00% ±  7.01%

         ▁▆█▇▄▃▃▂▁▁                                            ▁
  ▅▄▆██▆▇█████████████▇▆▅▅▄▅▄▆▆▆▆▆▅▅▆▆▆▇▆▇▆▅▆▆▆▆▆▆▅▄▅▅▅▃▅▃▄▄▄▃ █
  30.5 μs       Histogram: log(frequency) by time       130 μs <

 Memory estimate: 248.20 KiB, allocs estimate: 99.
```

With this PR (custom rrule for `_with_ladj_on_mapped`):

```julia
julia> @benchmark grad_foo($xs)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  19.175 μs …  2.898 ms  ┊ GC (min … max):  0.00% … 93.90%
 Time  (median):     27.598 μs              ┊ GC (median):     0.00%
 Time  (mean ± σ):   34.333 μs ± 81.148 μs  ┊ GC (mean ± σ):  12.31% ±  5.25%

         ▁▄▇█▇▅▄▃▃▂▁▁▁ ▁▁▂▃▃▃▂▂▁                              ▂
  ▄▆▅▃▃▅▇█████████████████████████▇▇▇▇▇▆▆▅▆▅▅▆▄▅▄▄▅▄▅▄▃▄▄▄▅▄▄ █
  19.2 μs      Histogram: log(frequency) by time      64.4 μs <

 Memory estimate: 136.44 KiB, allocs estimate: 50.
```