### PR TITLE
refactor: prefix extensions with package name

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 
 [extensions]
-ChainRulesCoreExt = "ChainRulesCore"
+ChangesOfVariablesChainRulesCoreExt = "ChainRulesCore"
 
 [compat]
 ChainRulesCore = "1"

--- a/ext/ChangesOfVariablesChainRulesCoreExt.jl
+++ b/ext/ChangesOfVariablesChainRulesCoreExt.jl
@@ -1,4 +1,4 @@
-module ChainRulesCoreExt
+module ChangesOfVariablesChainRulesCoreExt
 
 using ChainRulesCore
 

--- a/src/ChangesOfVariables.jl
+++ b/src/ChangesOfVariables.jl
@@ -15,7 +15,7 @@ using Test
 include("with_ladj.jl")
 include("test.jl")
 if !isdefined(Base, :get_extension)
-    include("../ext/ChainRulesCoreExt.jl")
+    include("../ext/ChangesOfVariablesChainRulesCoreExt.jl")
 end
 
 end # module


### PR DESCRIPTION
- this will ensure extension names are unique
- whenever there is another package with same ext name, building sysimage fails
- ex: LogExpFunctions has its own ChainRulesCoreExt.jl


Ex: https://github.com/SciML/DiffEqBase.jl/tree/master/ext follows this for above mentioned reasons